### PR TITLE
Ambient nether lighting increase (Old)

### DIFF
--- a/shaders/glsl/renderchunk.fragment
+++ b/shaders/glsl/renderchunk.fragment
@@ -139,7 +139,7 @@ void main()
 	vec3 resultLighting = skyLightDiffused.rgb * skyLightDiffused.a * ambientOclusionMap;	
 
     //this two lines should be executed before building reflection
-	resultLighting += vec3((isHell - isUnderWater )* 0.175);// Ambient highlighting in hell gonna be refflected 
+	resultLighting += vec3((isHell - isUnderWater )* 0.3); // Ambient highlighting in hell gonna be reflected 
 	resultLighting += pointLightsDiffused * 0.25;//imagine this is a reflection of 25% of an evironment hihglighted by point light
 	
 	vec4 skyLightReflected = clamp(buildRawSkyReflection(relativePosition.xyz, resultLighting), 0.0, 1.0);


### PR DESCRIPTION
With the current lighting, it is nearly impossible to see anything when you are in a tight space
I am proposing that the ambient lighting should be roughly doubled to make the nether lighting practical for survival mode.
Screenshots:

Before:

![image](https://user-images.githubusercontent.com/48618519/114253087-7fa0e500-99a0-11eb-830a-cdfa3aa87e25.png)

After:

![image](https://user-images.githubusercontent.com/48618519/114253095-86c7f300-99a0-11eb-8f71-63cfe679b956.png)
<br>
<br>
![image](https://user-images.githubusercontent.com/48618519/114253100-8b8ca700-99a0-11eb-89f3-84a9c6849598.png)
