### PR TITLE
Corrected "intencity" to "intensity" across multiple variables

### DIFF
--- a/shaders/glsl/includes/lighting.glsl
+++ b/shaders/glsl/includes/lighting.glsl
@@ -28,7 +28,7 @@ vec4 calculateMainLightDiffused(vec3 normalVector, float isDay){
 vec3 calculatePointLightsDiffused(float srcPointLights){
 	float nearPointLightsBrightness = pow(srcPointLights * 1.15, 32.0);
 	float overalPointLightsBrightness = pow(srcPointLights, 2.0) * 0.5 + nearPointLightsBrightness;
-	overalPointLightsBrightness *= POINT_LIGHTS_INTENCITY;
+	overalPointLightsBrightness *= POINT_LIGHTS_intensity;
 	overalPointLightsBrightness = clamp(overalPointLightsBrightness, 0.0, 2.0);
 	// vec3 pointLightsTint = vec3(1.0, 0.66, 0.33);
 	vec4 pointLights = vec4(1.0);

--- a/shaders/glsl/includes/options/preset/lighting.glsl
+++ b/shaders/glsl/includes/options/preset/lighting.glsl
@@ -1,9 +1,9 @@
 #define POINT_LIGHTS_TINT vec3(1.0, 0.66, 0.33)
-#define POINT_LIGHTS_INTENCITY 2.0
+#define POINT_LIGHTS_INTENSITY 2.0
 #define MAIN_LIGHT_DIRRECTION vec3(0.9, 0.5, 0.0) //used only for reflection
 #define MAIN_LIGHT_SUN_COLOR vec3(1.0, 0.88, 0.69)
 #define MAIN_LIGHT_MOON_COLOR vec3(0.35, 0.6,1.0)
 #define SKY_LIGHT_SATURATION 0.6 //horizon color and diffuse sky light
 #define SKY_ZENITH_TINT vec3(0.25, 0.5, 1.0)
 #define SHADOW_SHARPNESS 128.0
-#define NETHER_AMBIENT_LIGHT_INTENCITY  0.175
+#define NETHER_AMBIENT_LIGHT_INTENSITY  0.175

--- a/shaders/glsl/includes/random.glsl
+++ b/shaders/glsl/includes/random.glsl
@@ -40,20 +40,20 @@ float cloudsPerlin(int octaves, vec2 position){
 	highp float time = TIME;
 	float speed = 0.1;
 	float scaleMultiplier = pow(2.0, float(octaves)); //  smaller scale - bigger noise
-	float intencityMultiplier = 1.0;
+	float intensityMultiplier = 1.0;
 	float resultDevider = 0.0;
 
 	float noise = 0.0;
 
 	while(scaleMultiplier > 1.5){
-		noise += rand_bilinear(position * scaleMultiplier) * intencityMultiplier;
-		resultDevider += intencityMultiplier;
+		noise += rand_bilinear(position * scaleMultiplier) * intensityMultiplier;
+		resultDevider += intensityMultiplier;
 		scaleMultiplier /= 2.0;
-		intencityMultiplier *= 2.0;
+		intensityMultiplier *= 2.0;
 	}
 
-	noise += rand_bilinear(position + vec2(time * speed)) * intencityMultiplier;
-	resultDevider += intencityMultiplier;
+	noise += rand_bilinear(position + vec2(time * speed)) * intensityMultiplier;
+	resultDevider += intensityMultiplier;
 
 	return noise / resultDevider;
 

--- a/shaders/glsl/renderchunk.fragment
+++ b/shaders/glsl/renderchunk.fragment
@@ -180,7 +180,7 @@ void main()
 	vec3 resultLighting = skyLightDiffused.rgb * skyLightDiffused.a * ambientOclusionMap;	
 
     //this two lines should be executed before building reflection
-	resultLighting += vec3((isHell - isUnderWater ) * NETHER_AMBIENT_LIGHT_INTENCITY);// Ambient highlighting in hell gonna be refflected 
+	resultLighting += vec3((isHell - isUnderWater ) * NETHER_AMBIENT_LIGHT_INTENSITY);// Ambient highlighting in hell gonna be refflected 
 	resultLighting += pointLightsDiffused * 0.25;//imagine this is a reflection of 25% of an evironment hihglighted by point light
 	
 


### PR DESCRIPTION
### Summary:
Corrected multiple instances of the word "intensity" being spelled as "intencity" in variable names
