### PR TITLE
Revert subpacks

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,37 +17,5 @@
     "metadata": {
       "authors": ["Jebbyk", "OpenSauce", "LSumma", "BambooSapling"]
 
-    },
-    "subpacks": [
-        {
-            "folder_name": "lowest",
-			"name": "§a(LOWEST) : only basic functions\n\n§eAttention : RESTART MINECRAFT TO APPLY SETTINGS!!!",
-			"memory_tier": 1
-        },
-        {
-            "folder_name": "low",
-			"name": "§a(LOW) : balanced options for low end devices \n\n§eAttention : RESTART MINECRAFT TO APPLY SETTINGS!!!",
-			"memory_tier": 1
-        },
-        {
-            "folder_name": "medium",
-			"name": "§a(MEDIUM) : balanced options for most of the devices\n\n§eAttention : RESTART MINECRAFT TO APPLY SETTINGS!!!",
-			"memory_tier": 1
-        },
-        {
-            "folder_name": "high",
-			"name": "§a(HIGH) : default recommended setting for powerfull GPU\n\n§eAttention : RESTART MINECRAFT TO APPLY SETTINGS!!!",
-			"memory_tier": 1
-        },
-        {
-            "folder_name": "ultra",
-			"name": "§a(ULTRA) : even developer does not use this option, use if your phone is from 2023 or later\n\n§eAttention : RESTART MINECRAFT TO APPLY SETTINGS!!!",
-			"memory_tier": 1
-        },
-        {
-            "folder_name": "custom",
-			"name": "§a(CUSTOM) : use this if you know how to edit options files\n\n§eAttention : RESTART MINECRAFT TO APPLY SETTINGS!!!",
-			"memory_tier": 1
-        }
-    ]
+    }
 }

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
@@ -1,1 +1,0 @@
-#define ADVANCED_CLOUDS_SHADOW //comment this line to disable feature

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_DETAILS  4 //recomended values [0, 1, 2, 4, 8]

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
@@ -1,1 +1,0 @@
-#define CAUSTICS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
@@ -1,1 +1,0 @@
-#define SHADOWS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/other/blue_fog_enabled.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/other/blue_fog_enabled.glsl
@@ -1,1 +1,0 @@
-#define BLUE_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
@@ -1,1 +1,0 @@
-#define HORIZONTAL_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define TONE_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
@@ -1,2 +1,0 @@
-// comment this line to disable and uncomment to enable
-#define BETTER_MAIN_LIGHT_REFLECTION // makes main light reflection a bit softer

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_REFLECTION_ENABLED // comment this line to disable and uncomment to enable

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_REFLECTIONS_QUALITY 0 //recomended values [0, 1, 2]

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
@@ -1,1 +1,0 @@
-#define HALO_REFLECTION_ENABLED // controlls reflection of sunrize/sunset "halo" reflection

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
@@ -1,1 +1,0 @@
-#define MAIN_LIGHT_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
@@ -1,1 +1,0 @@
-#define POINT_LIGHTS_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define NORMAL_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
@@ -1,1 +1,0 @@
-#define PUDDLES_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define SPECULAR_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/custom/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
+++ b/subpacks/custom/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
@@ -1,1 +1,0 @@
-#define WATER_DETAILS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
@@ -1,1 +1,0 @@
-#define ADVANCED_CLOUDS_SHADOW //comment this line to disable feature

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_DETAILS  4 //recomended values [0, 1, 2, 4, 8]

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
@@ -1,1 +1,0 @@
-#define CAUSTICS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
@@ -1,1 +1,0 @@
-#define SHADOWS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/other/blue_fog_enabled.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/other/blue_fog_enabled.glsl
@@ -1,1 +1,0 @@
-#define BLUE_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
@@ -1,1 +1,0 @@
-#define HORIZONTAL_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define TONE_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
@@ -1,2 +1,0 @@
-// comment this line to disable and uncomment to enable
-#define BETTER_MAIN_LIGHT_REFLECTION // makes main light reflection a bit softer

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_REFLECTION_ENABLED // comment this line to disable and uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_REFLECTIONS_QUALITY 0 //recomended values [0, 1, 2]

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
@@ -1,1 +1,0 @@
-#define HALO_REFLECTION_ENABLED // controlls reflection of sunrize/sunset "halo" reflection

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
@@ -1,1 +1,0 @@
-#define MAIN_LIGHT_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
@@ -1,1 +1,0 @@
-#define POINT_LIGHTS_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define NORMAL_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
@@ -1,1 +1,0 @@
-#define PUDDLES_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define SPECULAR_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
@@ -1,1 +1,0 @@
-#define WATER_DETAILS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
@@ -1,1 +1,0 @@
-// #define ADVANCED_CLOUDS_SHADOW //comment this line to disable feature

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_DETAILS 0 //recomended values [0, 1, 2, 4, 8]

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
@@ -1,1 +1,0 @@
-// #define CAUSTICS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
@@ -1,1 +1,0 @@
-#define SHADOWS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/other/blue_fog_enabled.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/other/blue_fog_enabled.glsl
@@ -1,1 +1,0 @@
-#define BLUE_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
@@ -1,1 +1,0 @@
-// #define HORIZONTAL_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define TONE_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
@@ -1,2 +1,0 @@
-// comment this line to disable and uncomment to enable
-// #define BETTER_MAIN_LIGHT_REFLECTION // makes main light reflection a bit softer

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_REFLECTION_ENABLED // comment this line to disable and uncomment to enable

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_REFLECTIONS_QUALITY 0 //recomended values [0, 1, 2]

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
@@ -1,1 +1,0 @@
-// #define HALO_REFLECTION_ENABLED // controlls reflection of sunrize/sunset "halo" reflection

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
@@ -1,1 +1,0 @@
-#define MAIN_LIGHT_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
@@ -1,1 +1,0 @@
-// #define POINT_LIGHTS_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-// #define NORMAL_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
@@ -1,1 +1,0 @@
-// #define PUDDLES_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define SPECULAR_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/low/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
+++ b/subpacks/low/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
@@ -1,1 +1,0 @@
-// #define WATER_DETAILS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
@@ -1,1 +1,0 @@
-// #define ADVANCED_CLOUDS_SHADOW //comment this line to disable feature

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_DETAILS  0 //recomended values [0, 1, 2, 4, 8]

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
@@ -1,1 +1,0 @@
-// #define CLOUDS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
@@ -1,1 +1,0 @@
-// #define CAUSTICS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
@@ -1,1 +1,0 @@
-#define SHADOWS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/other/blue_fog_enabled.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/other/blue_fog_enabled.glsl
@@ -1,1 +1,0 @@
-#define BLUE_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
@@ -1,1 +1,0 @@
-// #define HORIZONTAL_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define TONE_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
@@ -1,2 +1,0 @@
-// comment this line to disable and uncomment to enable
-// #define BETTER_MAIN_LIGHT_REFLECTION // makes main light reflection a bit softer

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
@@ -1,1 +1,0 @@
-// #define CLOUDS_REFLECTION_ENABLED // comment this line to disable and uncomment to enable

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_REFLECTIONS_QUALITY 0 //recomended values [0, 1, 2]

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
@@ -1,1 +1,0 @@
-// #define HALO_REFLECTION_ENABLED // controlls reflection of sunrize/sunset "halo" reflection

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
@@ -1,1 +1,0 @@
-// #define MAIN_LIGHT_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
@@ -1,1 +1,0 @@
-// #define POINT_LIGHTS_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-// #define NORMAL_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
@@ -1,1 +1,0 @@
-// #define PUDDLES_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-// #define SPECULAR_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/lowest/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
+++ b/subpacks/lowest/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
@@ -1,1 +1,0 @@
-// #define WATER_DETAILS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
@@ -1,1 +1,0 @@
-// #define ADVANCED_CLOUDS_SHADOW //comment this line to disable feature

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_DETAILS  2 //recomended values [0, 1, 2, 4, 8]

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
@@ -1,1 +1,0 @@
-#define CAUSTICS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
@@ -1,1 +1,0 @@
-#define SHADOWS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/other/blue_fog_enabled.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/other/blue_fog_enabled.glsl
@@ -1,1 +1,0 @@
-#define BLUE_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
@@ -1,1 +1,0 @@
-// #define HORIZONTAL_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define TONE_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
@@ -1,2 +1,0 @@
-// comment this line to disable and uncomment to enable
-// #define BETTER_MAIN_LIGHT_REFLECTION // makes main light reflection a bit softer

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_REFLECTION_ENABLED // comment this line to disable and uncomment to enable

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_REFLECTIONS_QUALITY 0 //recomended values [0, 1, 2]

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
@@ -1,1 +1,0 @@
-// #define HALO_REFLECTION_ENABLED // controlls reflection of sunrize/sunset "halo" reflection

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
@@ -1,1 +1,0 @@
-#define MAIN_LIGHT_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
@@ -1,1 +1,0 @@
-// #define POINT_LIGHTS_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define NORMAL_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
@@ -1,1 +1,0 @@
-#define PUDDLES_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define SPECULAR_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/medium/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
+++ b/subpacks/medium/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
@@ -1,1 +1,0 @@
-#define WATER_DETAILS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
@@ -1,1 +1,0 @@
-#define ADVANCED_CLOUDS_SHADOW //comment this line to disable feature

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_DETAILS  8 //recomended values [0, 1, 2, 4, 8]

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
@@ -1,1 +1,0 @@
-#define CAUSTICS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
@@ -1,1 +1,0 @@
-#define SHADOWS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/other/blue_fog_enabled.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/other/blue_fog_enabled.glsl
@@ -1,1 +1,0 @@
-#define BLUE_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
@@ -1,1 +1,0 @@
-#define HORIZONTAL_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define TONE_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
@@ -1,2 +1,0 @@
-// comment this line to disable and uncomment to enable
-#define BETTER_MAIN_LIGHT_REFLECTION // makes main light reflection a bit softer

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_REFLECTION_ENABLED // comment this line to disable and uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
@@ -1,1 +1,0 @@
-#define CLOUDS_REFLECTIONS_QUALITY 2 //recomended values [0, 1, 2]

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
@@ -1,1 +1,0 @@
-#define HALO_REFLECTION_ENABLED // controlls reflection of sunrize/sunset "halo" reflection

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
@@ -1,1 +1,0 @@
-#define MAIN_LIGHT_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
@@ -1,1 +1,0 @@
-#define POINT_LIGHTS_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define NORMAL_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
@@ -1,1 +1,0 @@
-#define PUDDLES_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
@@ -1,1 +1,0 @@
-#define SPECULAR_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
@@ -1,1 +1,0 @@
-#define WATER_DETAILS_ENABLED //comment this line to disable this feture, uncomment to enable


### PR DESCRIPTION
This reverts commit 2d372529d067bcb7a1864e8da9bd2d0e508a2ee0.

### Summary:
Reverted the implemented subpack-based quality slider, as it was implemented incorrectly, causing the entire shader to be disabled

---------
### Screenshots:
<!--- Screenshots of your changes (In a before-and-after format if applicable) -->
