### PR TITLE
Increased nether lighting

### DIFF
--- a/shaders/glsl/includes/options/preset/lighting.glsl
+++ b/shaders/glsl/includes/options/preset/lighting.glsl
@@ -6,4 +6,4 @@
 #define SKY_LIGHT_SATURATION 0.6 //horizon color and diffuse sky light
 #define SKY_ZENITH_TINT vec3(0.25, 0.5, 1.0)
 #define SHADOW_SHARPNESS 128.0
-#define NETHER_AMBIENT_LIGHT_INTENCITY  0.175
+#define NETHER_AMBIENT_LIGHT_INTENCITY  0.3


### PR DESCRIPTION
*time to bring this one back from the grave*

### Summary:

With the current lighting, it is nearly impossible to see anything when you are in a tight space
To fix this, I've roughly doubled the base lighting intensity to make going to the nether more practical for survival mode.
`NETHER_AMBIENT_LIGHT_INTENCITY 0.175` --> `NETHER_AMBIENT_LIGHT_INTENCITY 0.3`

---

### Screenshots: (these are pretty old, but still relevant)

Before:

![image](https://user-images.githubusercontent.com/48618519/114253087-7fa0e500-99a0-11eb-830a-cdfa3aa87e25.png)

After:

![image](https://user-images.githubusercontent.com/48618519/114253095-86c7f300-99a0-11eb-8f71-63cfe679b956.png)
<br>
<br>
![image](https://user-images.githubusercontent.com/48618519/114253100-8b8ca700-99a0-11eb-89f3-84a9c6849598.png)