### PR TITLE
Header files are now detected as GLSL by github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.h linguist-language=glsl


### PR DESCRIPTION
### Summary:
Header files are now detected as GLSL via a linguist override in .gitattributes