### PR TITLE
Split the atlas dimension control and PBR toggle into different files

### DIFF
--- a/shaders/glsl/color_texture.fragment
+++ b/shaders/glsl/color_texture.fragment
@@ -29,7 +29,8 @@ varying vec4 fogColor;
 #endif
 
 
-#include "includes/options/preset/other.glsl"
+#include "includes/options/preset/atlas.glsl"
+#include "includes/options/preset/pbr.glsl"
 
 
 /////////////////////Ingame UI fragment shader////////////////////////////

--- a/shaders/glsl/entity.fragment
+++ b/shaders/glsl/entity.fragment
@@ -10,7 +10,8 @@
 #include "util.h"
 
 
-#include "includes/options/preset/other.glsl"
+#include "includes/options/preset/atlas.glsl"
+#include "includes/options/preset/pbr.glsl"
 
 LAYOUT_BINDING(0) uniform sampler2D TEXTURE_0;
 LAYOUT_BINDING(1) uniform sampler2D TEXTURE_1;

--- a/shaders/glsl/includes/options/preset/atlas.glsl
+++ b/shaders/glsl/includes/options/preset/atlas.glsl
@@ -1,0 +1,1 @@
+#define TEXTURE_ATLAS_DIMENSION vec2(64.0, 32.0) // Number of rows and columns in texture atlas. Don't Change these values unless you know what you are doing

--- a/shaders/glsl/includes/options/preset/other.glsl
+++ b/shaders/glsl/includes/options/preset/other.glsl
@@ -1,4 +1,0 @@
-// this file is used to support dfifferent types fo texturepacks
-
-#define TEXTURE_ATLAS_DIMENSION vec2(64.0, 32.0) // number of rows and columns in texture atlas. most of the times it should not be changed
-// #define PBR_FEATURE_ENABLED  // comment this line if you are using simple (non pbr) texture pack

--- a/shaders/glsl/includes/options/preset/pbr.glsl
+++ b/shaders/glsl/includes/options/preset/pbr.glsl
@@ -1,0 +1,1 @@
+// #define PBR_FEATURE_ENABLED  // comment this line if you are using simple (non pbr) texture pack

--- a/shaders/glsl/renderchunk.fragment
+++ b/shaders/glsl/renderchunk.fragment
@@ -28,7 +28,8 @@
 #include "includes/options/preset/fogs.glsl"
 #include "includes/options/preset/surface.glsl"
 #include "includes/options/preset/postprocessing.glsl"
-#include "includes/options/preset/other.glsl"
+#include "includes/options/preset/atlas.glsl"
+#include "includes/options/preset/pbr.glsl"
 
 #if __VERSION__ >= 300
 	#ifndef BYPASS_PIXEL_SHADER


### PR DESCRIPTION
### Summary:
As the title says, this PR will split the variable that controls the atlas dimension and the variable that toggles whether PBR is enabled or not into different files. This is a future-proofing measure to ensure that if Mojang tweaks the atlas size, the end users won't need to manually tweak the `other.glsl` file with updated values for older PBR texture packs, as currently, the PBR toggle must *also* include the atlas dimensions alongside it.

I am aware that this change will break existing PBR packs, but the benefit here definitely seems worth it, and it's an incredibly simple fix if just removing the old `other.glsl` file and replacing it with the new `pbr.glsl` file in the same place
