### PR TITLE
Temporarily move Parallax Mapping to an experimental setting until issues are fixed

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -45,7 +45,7 @@
 			"memory_tier": 4
         },
 		{
-            "folder_name": "high",
+            "folder_name": "experimental",
 			"name": "§c[EXPERIMENAL] §a: Has the same quality as High, except the experimental Parallax Mapping feature is enabled\n\n§eAttention : RESTART MINECRAFT TO APPLY SETTINGS!!!",
 			"memory_tier": -1
         }

--- a/manifest.json
+++ b/manifest.json
@@ -43,6 +43,11 @@
             "folder_name": "high",
 			"name": "§a[HIGH (DEFAULT)] : Recommended settings for a relatively powerful GPU\n\n§eAttention : RESTART MINECRAFT TO APPLY SETTINGS!!!",
 			"memory_tier": 4
+        },
+		{
+            "folder_name": "high",
+			"name": "§c[EXPERIMENAL] §a: Has the same quality as High, except the experimental Parallax Mapping feature is enabled\n\n§eAttention : RESTART MINECRAFT TO APPLY SETTINGS!!!",
+			"memory_tier": -1
         }
     ]
 }

--- a/shaders/glsl/includes/options/quality_settings/surface/parallax_mapping_enabled.glsl
+++ b/shaders/glsl/includes/options/quality_settings/surface/parallax_mapping_enabled.glsl
@@ -1,1 +1,1 @@
-#define PARALLAX_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable
+// #define PARALLAX_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/animations/underwater_distortion.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/animations/underwater_distortion.glsl
@@ -1,0 +1,1 @@
+#define UNDERWATER_DISTORTION //Comment this line to disable underwater distortion

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/animations/vegetation_animation.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/animations/vegetation_animation.glsl
@@ -1,0 +1,1 @@
+#define VEGETATION_ANIMATION//Comment this line to disable vegetation animation

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/animations/water_surface_animation.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/animations/water_surface_animation.glsl
@@ -1,0 +1,1 @@
+#define WATER_SURFACE_ANIMATION//Comment this line to disable water surface animation

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/clouds/advanced_clouds_shadow.glsl
@@ -1,0 +1,1 @@
+#define ADVANCED_CLOUDS_SHADOW //comment this line to disable feature

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/clouds/clouds_details.glsl
@@ -1,0 +1,1 @@
+#define CLOUDS_DETAILS  4 //recomended values [0, 1, 2, 4, 8]

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/clouds/clouds_enabled.glsl
@@ -1,0 +1,1 @@
+#define CLOUDS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/lighting/caustics_enabled.glsl
@@ -1,0 +1,1 @@
+#define CAUSTICS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/lighting/shadows_enabled.glsl
@@ -1,0 +1,1 @@
+#define SHADOWS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/other/distance_fog_enabled.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/other/distance_fog_enabled.glsl
@@ -1,0 +1,1 @@
+#define DISTANCE_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/other/horizontal_fog_enabled.glsl
@@ -1,0 +1,1 @@
+#define HORIZONTAL_FOG_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/other/tone_mapping_enabled.glsl
@@ -1,0 +1,1 @@
+#define TONE_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/reflections/better_main_light_reflection.glsl
@@ -1,0 +1,2 @@
+// comment this line to disable and uncomment to enable
+#define BETTER_MAIN_LIGHT_REFLECTION // makes main light reflection a bit softer

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflection_enabled.glsl
@@ -1,0 +1,1 @@
+#define CLOUDS_REFLECTION_ENABLED // comment this line to disable and uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/reflections/clouds_reflections_quality.glsl
@@ -1,0 +1,1 @@
+#define CLOUDS_REFLECTIONS_QUALITY 0 //recomended values [0, 1, 2]

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/reflections/halo_reflection.glsl
@@ -1,0 +1,1 @@
+#define HALO_REFLECTION_ENABLED // controlls reflection of sunrize/sunset "halo" reflection

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/reflections/main_light_reflection.glsl
@@ -1,0 +1,1 @@
+#define MAIN_LIGHT_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/reflections/point_lights_reflection.glsl
@@ -1,0 +1,1 @@
+#define POINT_LIGHTS_REFLECTION // comment this line to disable and uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/surface/normal_mapping_enabled.glsl
@@ -1,0 +1,1 @@
+#define NORMAL_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/surface/parallax_mapping_enabled.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/surface/parallax_mapping_enabled.glsl
@@ -1,0 +1,1 @@
+#define PARALLAX_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/surface/puddles_enabled.glsl
@@ -1,0 +1,1 @@
+#define PUDDLES_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/surface/specular_mapping_enabled.glsl
@@ -1,0 +1,1 @@
+#define SPECULAR_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/experimental/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
+++ b/subpacks/experimental/shaders/glsl/includes/options/quality_settings/surface/water_details_enabled.glsl
@@ -1,0 +1,1 @@
+#define WATER_DETAILS_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/high/shaders/glsl/includes/options/quality_settings/surface/parallax_mapping_enabled.glsl
+++ b/subpacks/high/shaders/glsl/includes/options/quality_settings/surface/parallax_mapping_enabled.glsl
@@ -1,1 +1,1 @@
-#define PARALLAX_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable
+// #define PARALLAX_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable

--- a/subpacks/ultra/shaders/glsl/includes/options/quality_settings/surface/parallax_mapping_enabled.glsl
+++ b/subpacks/ultra/shaders/glsl/includes/options/quality_settings/surface/parallax_mapping_enabled.glsl
@@ -1,1 +1,1 @@
-#define PARALLAX_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable
+// #define PARALLAX_MAPPING_ENABLED //comment this line to disable this feture, uncomment to enable


### PR DESCRIPTION
### Summary:
Due to the texture issues that have been caused by having parallax mapping enabled (#243, #244), I have temporarily removed the feature from the normal quality settings of the game and placed it in an Experiemental quality setting.
It will be re-enabled as it was before when these issues have been fixed
This change should be released as an update soon after this is pulled so that people can disable this feature without degrading their quality settings or editing the code of the shader

---------
### Screenshots:
<!--- Screenshots of your changes (In a before-and-after format if applicable) -->
